### PR TITLE
Include the current extension

### DIFF
--- a/src/integration/Extend/OverrideExtensionManagerForTests.php
+++ b/src/integration/Extend/OverrideExtensionManagerForTests.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Flarum\Testing\integration\Extend;
+
+use Flarum\Extend\ExtenderInterface;
+use Flarum\Extension\Extension;
+use Flarum\Testing\integration\Extension\ExtensionManagerIncludeCurrent;
+use Illuminate\Contracts\Container\Container;
+
+class OverrideExtensionManagerForTests implements ExtenderInterface
+{
+    /**
+     * IDs of extensions to boot
+     */
+    protected $extensions;
+
+    public function __construct($extensions)
+    {
+        $this->extensions = $extensions;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        if (count($this->extensions)) {
+            $container->bind(ExtensionManager::class, ExtensionManagerIncludeCurrent::class);
+            $extensionManager = $container->make(ExtensionManager::class);
+
+            foreach ($this->extensions as $extension) {
+                $extensionManager->enable($extension);
+            }
+
+            $extensionManager->extend($container);
+        }
+    }
+}

--- a/src/integration/Extension/ExtensionManagerIncludeCurrent.php
+++ b/src/integration/Extension/ExtensionManagerIncludeCurrent.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace Flarum\Testing\integration\Extension;
+
+use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionManager;
+use Illuminate\Support\Arr;
+
+class ExtensionManagerIncludeCurrent extends ExtensionManager
+{
+    /**
+     * @return Collection
+     */
+    public function getExtensions()
+    {
+        $extensions = parent::getExtensions();
+
+        $package = json_decode($this->filesystem->get($this->paths->vendor . '/../composer.json'), true);
+
+        if (Arr::get($package, 'type') === 'flarum-extension') {
+            $current = new Extension($this->paths->vendor . '/../', $package);
+            $current->setInstalled(true);
+            $current->setVersion(Arr::get($package, 'version'));
+            $current->calculateDependencies([]);
+
+            $extensions->put($current->getId(), $current);
+
+            $this->extensions = $extensions->sortBy(function ($extension, $name) {
+                return $extension->composerJsonAttribute('extra.flarum-extension.title');
+            });
+        }
+
+        return $this->extensions;
+    }
+}

--- a/src/integration/TestCase.php
+++ b/src/integration/TestCase.php
@@ -13,6 +13,7 @@ use Flarum\Extend\ExtenderInterface;
 use Flarum\Foundation\Config;
 use Flarum\Foundation\InstalledSite;
 use Flarum\Foundation\Paths;
+use Flarum\Testing\integration\Extend\OverrideExtensionManagerForTests;
 use Illuminate\Database\ConnectionInterface;
 use Laminas\Diactoros\ServerRequest;
 use Psr\Http\Message\ResponseInterface;
@@ -51,10 +52,14 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
                     'public' => __DIR__.'/tmp/public',
                     'storage' => __DIR__.'/tmp/storage',
                 ]),
-                new Config(include __DIR__.'/tmp/config.php')
+                new Config(include __DIR__ . '/tmp/config.php')
             );
 
-            $site->extendWith($this->extenders);
+            $extenders = array_merge([
+                new OverrideExtensionManagerForTests($this->extensions)
+            ], $this->extenders);
+
+            $site->extendWith($extenders);
 
             $this->app = $site->bootApp();
 
@@ -74,6 +79,16 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     protected function extend(ExtenderInterface ...$extenders)
     {
         $this->extenders = array_merge($this->extenders, $extenders);
+    }
+
+    /**
+     * @var string[]
+     */
+    protected $extensions = [];
+
+    protected function extension(string ...$extensions)
+    {
+        $this->extensions = array_merge($this->extensions, $extensions);
     }
 
     /**


### PR DESCRIPTION
Ref https://github.com/flarum/core/issues/2543

Core's ExtensionManager only looks for extensions in the vendor directory, which makes sense for a Flarum instance, but is problematic if used in the context of a test suite for an extension. This PR:

- Adds a class extending ExtensionManager to include the current package
- Adds an extender that replaces ExtensionManager with this new class in container bindings