### PR TITLE
Fix extension testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ composer.phar
 node_modules
 .DS_Store
 Thumbs.db
-/tests/integration/tmp
+/src/integration/tmp
 .vagrant
 .idea/*
 .vscode

--- a/src/integration/Extension/ExtensionManagerIncludeCurrent.php
+++ b/src/integration/Extension/ExtensionManagerIncludeCurrent.php
@@ -28,7 +28,7 @@ class ExtensionManagerIncludeCurrent extends ExtensionManager
             $current = new Extension($this->paths->vendor . '/../', $package);
             $current->setInstalled(true);
             $current->setVersion(Arr::get($package, 'version'));
-            $current->calculateDependencies([]);
+            $current->calculateDependencies([], []);
 
             $extensions->put($current->getId(), $current);
 


### PR DESCRIPTION
Optional dependencies was added in beta 16, which added a new required argument to `calculateDependencies` which requires us to update this package to work properly, we didn't notice it because we only use it in core right now, which doesn't make use of `$this->extension()`.

Also added the tmp folder to .gitignore