### PR TITLE
Fix variable names

### DIFF
--- a/src/integration/Setup/SetupScript.php
+++ b/src/integration/Setup/SetupScript.php
@@ -32,7 +32,7 @@ class SetupScript
      *
      * @var int
      */
-    protected $post;
+    protected $port;
 
     /**
      * Test database name.
@@ -60,7 +60,7 @@ class SetupScript
      *
      * @var string
      */
-    protected $prefix;
+    protected $pref;
 
     public function __construct()
     {


### PR DESCRIPTION
Someone made some mistakes when writing this.

It's not causing any issue because the correct variable name is always used to set and read the value, and PHP is fine setting new attributes on a class dynamically. It's just the explicit variables declared don't match with those actually used later.