### PR TITLE
Add missing import for ExtensionManager

### DIFF
--- a/src/integration/Extend/OverrideExtensionManagerForTests.php
+++ b/src/integration/Extend/OverrideExtensionManagerForTests.php
@@ -4,6 +4,7 @@ namespace Flarum\Testing\integration\Extend;
 
 use Flarum\Extend\ExtenderInterface;
 use Flarum\Extension\Extension;
+use Flarum\Extension\ExtensionManager;
 use Flarum\Testing\integration\Extension\ExtensionManagerIncludeCurrent;
 use Illuminate\Contracts\Container\Container;
 
@@ -22,7 +23,7 @@ class OverrideExtensionManagerForTests implements ExtenderInterface
     public function extend(Container $container, Extension $extension = null)
     {
         if (count($this->extensions)) {
-            $container->bind(ExtensionManager::class, ExtensionManagerIncludeCurrent::class);
+            $container->singleton(ExtensionManager::class, ExtensionManagerIncludeCurrent::class);
             $extensionManager = $container->make(ExtensionManager::class);
 
             foreach ($this->extensions as $extension) {


### PR DESCRIPTION
Add missing import for ExtensionManager
Replace bind with singleton, otherwise singleton behavior is lost

The old code was working, because we bound the class to the invalid namespace, but then resolved from the same invalid namespace.

This fixes the import and actually make it so our alternate ExtensionManager stays a singleton.