### PR TITLE
Start transactions before the app is fully booted.

### DIFF
--- a/src/integration/Extend/BeginTransactionAndSetDatabase.php
+++ b/src/integration/Extend/BeginTransactionAndSetDatabase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Flarum\Testing\integration\Extend;
+
+use Flarum\Extend\ExtenderInterface;
+use Flarum\Extension\Extension;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Database\ConnectionInterface;
+
+class BeginTransactionAndSetDatabase implements ExtenderInterface
+{
+    /**
+     * A callback to set the database connection object on the test case.
+     */
+    protected $setDbOnTestCase;
+
+    public function __construct(callable $setDbOnTestCase)
+    {
+        $this->setDbOnTestCase = $setDbOnTestCase;
+    }
+
+    public function extend(Container $container, Extension $extension = null)
+    {
+        $db = $container->make(ConnectionInterface::class);
+
+        $db->beginTransaction();
+
+        ($this->setDbOnTestCase)($db);
+    }
+}

--- a/src/integration/TestCase.php
+++ b/src/integration/TestCase.php
@@ -13,6 +13,7 @@ use Flarum\Extend\ExtenderInterface;
 use Flarum\Foundation\Config;
 use Flarum\Foundation\InstalledSite;
 use Flarum\Foundation\Paths;
+use Flarum\Testing\integration\Extend\BeginTransactionAndSetDatabase;
 use Flarum\Testing\integration\Extend\OverrideExtensionManagerForTests;
 use Flarum\Testing\integration\Extend\SetSettingsBeforeBoot;
 use Illuminate\Database\ConnectionInterface;
@@ -61,6 +62,9 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
             $extenders = array_merge([
                 new OverrideExtensionManagerForTests($this->extensions),
+                new BeginTransactionAndSetDatabase(function (ConnectionInterface $db) {
+                    $this->database = $db;
+                }),
                 new SetSettingsBeforeBoot($this->settings),
             ], $this->extenders);
 
@@ -150,12 +154,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     protected function database(): ConnectionInterface
     {
-        if (is_null($this->database)) {
-            $this->database = $this->app()->getContainer()->make(
-                ConnectionInterface::class
-            );
-        }
-
+        // Set in `BeginTransactionAndSetDatabase` extender.
         return $this->database;
     }
 

--- a/tests/tests/integration/TestCaseTest.php
+++ b/tests/tests/integration/TestCaseTest.php
@@ -49,6 +49,17 @@ class TestCaseTest extends TestCase
     /**
      * @test
      */
+    public function settings_cleaned_up_from_previous_method()
+    {
+        $settings = $this->app()->getContainer()->make(SettingsRepositoryInterface::class);
+
+        $this->assertEquals(null, $settings->get('hello'));
+        $this->assertEquals(null, $settings->get('display_name_driver'));
+    }
+
+    /**
+     * @test
+     */
     public function current_extension_not_applied_by_default()
     {
         $response = $this->send(


### PR DESCRIPTION
This make a cleaner state more likely, and ensures that settings set via `$this->setting` are cleaned up after the test case runs.

Prevents things like https://github.com/flarum/core/pull/2721#issuecomment-817422358